### PR TITLE
Fix/backend/order instead feed

### DIFF
--- a/backend/crop_domain/src/market/model.rs
+++ b/backend/crop_domain/src/market/model.rs
@@ -33,7 +33,7 @@ pub struct Market {
     // これ保存しておく必要ある？
     orders: Vec<Order>,
     // 直近30minの1秒刻みの価格の推移履歴
-    price_history: PriceHistory,
+    pub price_history: PriceHistory,
     // 各アウトカムどれくらいのShareが流通しているか
     shares: HashMap<Outcome, ShareNum>,
     price_computer: PriceComputer,

--- a/backend/crop_domain/src/market/model.rs
+++ b/backend/crop_domain/src/market/model.rs
@@ -1,5 +1,6 @@
 pub mod computer;
 pub mod num;
+pub mod price_history;
 
 use crate::account::model::AccountName;
 use crate::market::model::computer::PriceComputer;
@@ -30,6 +31,8 @@ pub struct Market {
      */
     // これ保存しておく必要ある？
     orders: Vec<Order>,
+    // 直近30minの1秒刻みの価格の推移履歴
+    // price_history: PriceHistory,
     // 各アウトカムどれくらいのShareが流通しているか
     shares: HashMap<Outcome, ShareNum>,
     price_computer: PriceComputer,

--- a/backend/crop_domain/src/market/model/computer.rs
+++ b/backend/crop_domain/src/market/model/computer.rs
@@ -93,6 +93,6 @@ mod tests {
         // outcomeをひとつ買うときの価格
         let price = lmsr.compute_price(&distri, Outcome::Realize);
 
-        assert_eq!(price, Some(TipNum(504)));
+        assert_eq!(price, TipNum(504));
     }
 }

--- a/backend/crop_domain/src/market/model/num.rs
+++ b/backend/crop_domain/src/market/model/num.rs
@@ -1,6 +1,9 @@
 use derive_more::{Add, AddAssign};
+use schemars::JsonSchema;
+use serde::Serialize;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(transparent)]
 pub struct TipNum(pub(in crate::market) i32);
 
 impl TipNum {

--- a/backend/crop_domain/src/market/model/price_history.rs
+++ b/backend/crop_domain/src/market/model/price_history.rs
@@ -1,0 +1,83 @@
+use crate::market::model::num::TipNum;
+use chrono::{DateTime, Utc};
+use std::collections::LinkedList;
+
+pub struct PriceHistory {
+    // 直近の1秒刻みの価格の推移履歴
+    in_sec: LinkedList<PriceHistoryItem>,
+    // 1秒刻みの価格レコードの最大保持数
+    max_item_in_sec: usize,
+    // 将来的に1分刻みの価格なども保存する
+}
+
+impl PriceHistory {
+    fn new(max_item_in_sec: usize) -> PriceHistory {
+        PriceHistory {
+            in_sec: LinkedList::new(),
+            max_item_in_sec,
+        }
+    }
+
+    pub fn push_item(&mut self, time: &DateTime<Utc>, price: TipNum) {
+        self.push_item_to_in_sec(time, price);
+    }
+
+    fn push_item_to_in_sec(&mut self, time: &DateTime<Utc>, price: TipNum) {
+        if self.is_need_push(time) {
+            self.in_sec.push_back(PriceHistoryItem::new(*time, price));
+            if self.in_sec.len() > self.max_item_in_sec {
+                self.in_sec.pop_front();
+            }
+        }
+    }
+
+    fn is_need_push(&self, time: &DateTime<Utc>) -> bool {
+        if let Some(last_item) = self.in_sec.back() {
+            seconds_of(&last_item.time) < seconds_of(time)
+        } else {
+            true
+        }
+    }
+}
+
+impl Default for PriceHistory {
+    fn default() -> PriceHistory {
+        // 最低でも1時間分は保存しておく
+        // 更新頻度が1秒より長くなった場合、履歴は
+        // 1時間ぶんよりも長くなることがある。
+        PriceHistory::new(60 * 60)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct PriceHistoryItem {
+    time: DateTime<Utc>,
+    price: TipNum,
+}
+
+impl PriceHistoryItem {
+    fn new(time: DateTime<Utc>, price: TipNum) -> PriceHistoryItem {
+        PriceHistoryItem { time, price }
+    }
+}
+
+fn seconds_of(time: &DateTime<Utc>) -> i64 {
+    time.timestamp()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn outdated_item_should_pruned() {
+        // 最大履歴保持数を1で作成
+        let mut history = PriceHistory::new(1);
+
+        history.push_item(&Utc::now(), TipNum(42));
+        assert_eq!(history.in_sec.len(), 1);
+
+        history.push_item(&Utc::now(), TipNum(42));
+        assert_eq!(history.in_sec.len(), 1);
+    }
+}

--- a/backend/crop_domain/src/market/model/price_history.rs
+++ b/backend/crop_domain/src/market/model/price_history.rs
@@ -1,6 +1,6 @@
 use crate::market::model::num::TipNum;
 use chrono::{DateTime, Utc};
-use std::collections::LinkedList;
+use std::collections::{linked_list::Iter, LinkedList};
 
 pub struct PriceHistory {
     // 直近の1秒刻みの価格の推移履歴
@@ -37,6 +37,10 @@ impl PriceHistory {
         } else {
             true
         }
+    }
+
+    pub fn iter_in_sec(&self) -> Iter<PriceHistoryItem> {
+        self.in_sec.iter()
     }
 }
 

--- a/backend/crop_domain/src/market/order/model.rs
+++ b/backend/crop_domain/src/market/order/model.rs
@@ -1,10 +1,13 @@
 use crate::account::model::AccountName;
 use crate::market::model::{num::TipNum, Outcome};
 use chrono::{DateTime, Utc};
+use schemars::JsonSchema;
+use serde::Serialize;
 use uuid::Uuid;
 
 /// 対象のOutcomeのShareを1つ買うOrderを表現するモデル
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct Order {
     pub id: OrderId,
     pub time: DateTime<Utc>,
@@ -31,7 +34,8 @@ impl Order {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(transparent)]
 pub struct OrderId(Uuid);
 
 impl OrderId {

--- a/backend/crop_server/src/routes/ws/msg.rs
+++ b/backend/crop_server/src/routes/ws/msg.rs
@@ -1,7 +1,4 @@
-use crop_domain::{
-    account::model::AccountName,
-    market::{model::Outcome, order::model::Order},
-};
+use crop_domain::market::order::model::Order;
 use schemars::JsonSchema;
 use serde::Serialize;
 use warp::filters::ws::Message;
@@ -16,45 +13,12 @@ use warp::filters::ws::Message;
 #[derive(Serialize, Clone, JsonSchema)]
 #[serde(tag = "type")]
 pub enum OutgoingMsg {
-    Feed(FeedMsg),
+    #[serde(rename = "order")]
+    Order(Order),
 }
 
 impl Into<Message> for OutgoingMsg {
     fn into(self) -> Message {
         Message::text(serde_json::to_string(&self).unwrap())
-    }
-}
-
-/// ```json
-/// {
-///     "type": "feed",
-///     "outcomeId": "4ef1a321-61bd-4c56-84c1-ddb327d38b91",
-///     "accountName": "Atsuking",
-///     "timestamp": 1583316553000
-/// }
-/// ```
-#[derive(Serialize, Clone, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct FeedMsg {
-    pub outcome: Outcome,
-    pub account_name: AccountName,
-    /// Unixタイムスタンプのms表現
-    /// https://docs.rs/chrono/0.4.10/chrono/struct.DateTime.html#method.timestamp_millis
-    pub timestamp: i64,
-}
-
-impl Into<Message> for FeedMsg {
-    fn into(self) -> Message {
-        OutgoingMsg::Feed(self).into()
-    }
-}
-
-impl From<Order> for FeedMsg {
-    fn from(order: Order) -> FeedMsg {
-        FeedMsg {
-            outcome: order.outcome,
-            account_name: order.account_name,
-            timestamp: order.time.timestamp_millis(),
-        }
     }
 }

--- a/backend/crop_server/src/routes/ws/session.rs
+++ b/backend/crop_server/src/routes/ws/session.rs
@@ -1,5 +1,5 @@
 use crate::context::market::MarketManager;
-use crate::routes::ws::msg::FeedMsg;
+use crate::routes::ws::msg::OutgoingMsg;
 use crop_domain::market::order::model::Order;
 use futures::{
     sink::{Sink, SinkExt as _},
@@ -32,7 +32,7 @@ async fn handle_outgoing(
 ) {
     let mut msg_stream = subscriber
         .err_into::<anyhow::Error>()
-        .map_ok(|order| FeedMsg::from(order).into());
+        .map_ok(|order| OutgoingMsg::Order(order).into());
     sink.sink_err_into::<anyhow::Error>()
         .send_all(&mut msg_stream)
         .await


### PR DESCRIPTION
`FeedMsg` の代わりに `OrderMsg` をpublishする