### PR TITLE
Feedの修正

### DIFF
--- a/frontend/src/app/components/color.ts
+++ b/frontend/src/app/components/color.ts
@@ -44,11 +44,11 @@ export const ChoiceBlue = Color.fromHex("#4583E4");
 export const ChoiceGreen = Color.fromHex("#57E445");
 export const ChoiceYellow = Color.fromHex("#E4DC45");
 export const ChoicePink = Color.fromHex("#E445B3");
+export const Gallery = Color.fromHex("#F0F0F0");
 
 export const WildWatermelon = Color.fromHex("#fd6585");
 export const ToreaBay = Color.fromHex("#0d25b9");
 export const Alto = Color.fromHex("#d8d8d8");
-
 
 export const Correct = Color.fromHex("#18e68c");
 

--- a/frontend/src/app/pages/instapoll/components/organisms/commentCard.tsx
+++ b/frontend/src/app/pages/instapoll/components/organisms/commentCard.tsx
@@ -14,10 +14,10 @@ interface Props {
 export const CommentCard: React.FC<Props> = ({ comment }) => {
   return (
     <Container>
-      <Account>
+      <FlagBlock>
         <ChoiceFlag flagColor={comment.color}></ChoiceFlag>
-        <UserName>{comment.account}</UserName>
-      </Account>
+      </FlagBlock>  
+      <UserName>{comment.account}</UserName>
       <Comment>{comment.comment}</Comment>
     </Container>
   );
@@ -35,13 +35,8 @@ const Container = styled.div`
   }
 `;
 
-const Account = styled.div`
-  display: flex;
-  justify-content: flex-start;
-  align-items: middle;
+const FlagBlock = styled.div`
   height: 16px;
-  margin-right: 4px;
-  font-weight: 400;
 `;
 
 const ChoiceFlag = styled.div<{ flagColor: string }>`
@@ -53,11 +48,17 @@ const ChoiceFlag = styled.div<{ flagColor: string }>`
 `;
 
 const UserName = styled.div`
+  max-width: 80px;
+  margin-right: 4px;
   font-size: 8px;
   line-height: 16px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `;
 
 const Comment = styled.div`
+  max-width: 220px;
   font-size: 12px;
   line-height: 16px;
   color: ${Gallery.hex};

--- a/frontend/src/app/pages/instapoll/components/organisms/commentCard.tsx
+++ b/frontend/src/app/pages/instapoll/components/organisms/commentCard.tsx
@@ -35,6 +35,7 @@ const Container = styled.div`
   }
 `;
 
+// Memo:CommentのheightにFlagの円（radius）が影響されるためFlagBlockで切り出す対応
 const FlagBlock = styled.div`
   height: 16px;
 `;

--- a/frontend/src/app/pages/instapoll/components/organisms/commentCard.tsx
+++ b/frontend/src/app/pages/instapoll/components/organisms/commentCard.tsx
@@ -3,8 +3,7 @@ import styled from "styled-components";
 
 import {
   WhiteBaseColor,
-  TextBaseColor,
-  BlackColor
+  Gallery
 } from "app/components/color";
 import { Comment as CommentModel } from "model/poll";
 
@@ -15,47 +14,51 @@ interface Props {
 export const CommentCard: React.FC<Props> = ({ comment }) => {
   return (
     <Container>
-      <Contents>
+      <Account>
+        <ChoiceFlag flagColor={comment.color}></ChoiceFlag>
         <UserName>{comment.account}</UserName>
-        <Comment>{comment.comment}</Comment>
-      </Contents>
-      <ChoiceFlag flagColor={comment.color}></ChoiceFlag>
+      </Account>
+      <Comment>{comment.comment}</Comment>
     </Container>
   );
 };
 
 const Container = styled.div`
-  width: 100%;
-  height: 36px;
-  margin-bottom: 16px;
-  border-radius: 4px;
-  background-color: ${WhiteBaseColor.hex}
   display: flex;
-  justify-content: space-between;
-  box-shadow: 0 2px 4px 0 ${BlackColor.rgba(0.5)};
+  justify-content: flex-start;
+  align-items: middle;
+  width: 100%;
+  margin-bottom: 16px;
+  color: ${WhiteBaseColor.hex};
+  &:last-child {
+    margin-bottom: 0;
+  }
 `;
 
-const Contents = styled.div`
-  padding: 2px 6px;
-  color: ${TextBaseColor.hex};
+const Account = styled.div`
+  display: flex;
+  justify-content: flex-start;
+  align-items: middle;
+  height: 16px;
+  margin-right: 4px;
+  font-weight: 400;
+`;
+
+const ChoiceFlag = styled.div<{ flagColor: string }>`
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  margin-right: 8px;
+  background-color: ${props => props.flagColor}
 `;
 
 const UserName = styled.div`
   font-size: 8px;
+  line-height: 16px;
 `;
 
 const Comment = styled.div`
   font-size: 12px;
-  font-weight: 500;
-`;
-
-const ChoiceFlag = styled.div<{ flagColor: string }>`
-  width: 25px;
-  border-radius: 0px 4px 4px 0px;
-  background: linear-gradient(
-      to bottom right,
-      rgba(255, 255, 255, 0) 50%,
-      ${props => props.flagColor} 50.5%
-    )
-    no-repeat top left/100% 100%;
+  line-height: 16px;
+  color: ${Gallery.hex};
 `;

--- a/frontend/src/app/pages/instapoll/index.tsx
+++ b/frontend/src/app/pages/instapoll/index.tsx
@@ -80,9 +80,41 @@ const testpoll = {
     KobeBeanBrsssssssssssssssssssssssssssssssssyant: "#e46345",
   }
 };
-const testcomments = [{
-  account: "test-account",
-  comment: "testtest",
-  color: "#424242"
-}];
+const testcomments = [
+  {
+    account: "Yuya_F",
+    comment: "いけえええええええええええええええええええええええええええええええええええええ!!!!",
+    color: "#4583e4"
+  },
+  {
+    account: "Atsuki",
+    comment: "いや、いくだろこれは",
+    color: "#4583e4"
+  },
+  {
+    account: "ふな",
+    comment: "Lebron風引いてるらしいぞ",
+    color: "#e46345"
+  },
+  {
+    account: "Yuya_F",
+    comment: "嘘やろ",
+    color: "#4583e4"
+  },
+  {
+    account: "Atsuki",
+    comment: "おわた",
+    color: "#c9c8c8"
+  },
+  {
+    account: "Atsuki",
+    comment: "やってくれんだろ",
+    color: "#4583e4"
+  },
+  {
+    account: "Yuya_F",
+    comment: "変えよう",
+    color: "#e46345"
+  }
+];
 const testtimer = 300;

--- a/frontend/src/app/pages/instapoll/index.tsx
+++ b/frontend/src/app/pages/instapoll/index.tsx
@@ -82,8 +82,8 @@ const testpoll = {
 };
 const testcomments = [
   {
-    account: "Yuya_F",
-    comment: "いけえええええええええええええええええええええええええええええええええええええ!!!!",
+    account: "Yuya_FYuya_FYuya_F",
+    comment: "いけえええええええええええええええええええええええええええええええええええええいけええ!!!!",
     color: "#4583e4"
   },
   {
@@ -102,8 +102,8 @@ const testcomments = [
     color: "#4583e4"
   },
   {
-    account: "Atsuki",
-    comment: "おわた",
+    account: "AtsukiAtsukiAtsukiAtsukiAtsukiAtsukiAtsuki",
+    comment: "おわたおわたおわたおわた",
     color: "#c9c8c8"
   },
   {

--- a/frontend/src/app/pages/instapoll/page.tsx
+++ b/frontend/src/app/pages/instapoll/page.tsx
@@ -5,7 +5,6 @@ import {
   WildWatermelon,
   ToreaBay,
   WhiteBaseColor,
-  TextBaseColor,
   BlackColor
 } from "app/components/color";
 import { Poll, Comment, Timer } from "model/poll";
@@ -120,11 +119,6 @@ const Logo = styled(LogoIcon)`
   margin-right: auto;
 `;
 
-const CommentFeed = styled.div`
-  width: 100%;
-  height: 50%;
-`;
-
 const PollCard = styled.div`
   border-radius: 4px;
   padding: 24px 14px 31px 14px;
@@ -142,6 +136,21 @@ const Theme = styled.div`
 
 const PollIndex = styled.span`
   margin-right: 4px;
+`;
+
+const CommentFeed = styled.div`
+  height: 190px;
+  margin: 0 14px 18px 14px;
+  overflow-y: scroll;
+  ::-webkit-scrollbar {
+    -webkit-appearance: none;
+    width: 7px;
+  }
+  ::-webkit-scrollbar-thumb {
+      border-radius: 4px;
+      background-color: rgba(0,0,0,.5);
+      box-shadow: 0 0 1px rgba(255,255,255,.5);
+  }
 `;
 
 const CommentContainer = styled.div`


### PR DESCRIPTION
修正内容
- [ ] Feedのデザイン修正
- [ ] コメント本文のカラー変更（sletchではopacityでやっていたが透明度表示が変なので。）
- [ ] スクロールが必要な場合にスクロールバー表示でスクロール
- [ ] 最後のコメントのみ、マージンは0になるように設定（最下部のコメント入力のマージンが空きすぎてしまうため）

**スクロール時**
<img width="324" alt="スクリーンショット 2020-04-12 17 49 37" src="https://user-images.githubusercontent.com/33197316/79064708-3adb6300-7ce6-11ea-8d41-700342abf648.png">

**最後のコメント**
<img width="322" alt="スクリーンショット 2020-04-12 17 49 44" src="https://user-images.githubusercontent.com/33197316/79064713-4038ad80-7ce6-11ea-927b-64a7f8ed4b18.png">
